### PR TITLE
Added gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/data.json


### PR DESCRIPTION
Rationale: This is a foundational best practice when maintaining public repositories.
`data.json` contains user-specific information that should not be tracked or distributed.
Ignoring this file prevents unnecessary data exposure and keeps the repository clean for collaborators and users alike.